### PR TITLE
perf(sgl-kernel): default block_quota=16 for MLA page_first KV gather on ROCm

### DIFF
--- a/sgl-kernel/python/sgl_kernel/kvcacheio.py
+++ b/sgl-kernel/python/sgl_kernel/kvcacheio.py
@@ -245,7 +245,7 @@ def transfer_kv_per_layer_mla_pf_lf(
     layer_id: int,
     item_size: int,
     src_layout_dim: int,
-    block_quota: int = 2,
+    block_quota: int = 16 if _is_hip else 2,
     num_warps_per_block: int = 16 if _is_hip else 32,
 ):
     torch.ops.sgl_kernel.transfer_kv_per_layer_mla_pf_lf.default(


### PR DESCRIPTION
## What
Raise the default `block_quota` from 2 → 16 (**HIP only**; CUDA unchanged) for `transfer_kv_per_layer_mla_pf_lf`, the MLA page_first L2→L1 `load_back` gather kernel.

```diff
-    block_quota: int = 2,
+    block_quota: int = 16 if _is_hip else 2,
     num_warps_per_block: int = 16 if _is_hip else 32,
```

## Why
On MI300X the gather launched with `block_quota=2`, underutilizing CUs. The per-layer gather stall is absorbed into `prefill_forward` (the compute stream waits on per-layer load events), so a slow gather directly inflates prefill latency whenever hicache `load_back` (L2→L1) fires.

## Measurement (Kimi-K2.6, 1P1D, L2-only hicache, MI300X + bnxt RoCE)
Single-variable A/B (block_quota 2 vs 16), cold per arm, heavy load_back regime (~77% of reqs, ~76–79M load_back tokens, equally exercised both arms):

| metric | block=2 | block=16 | Δ |
|---|---|---|---|
| prefill_forward | 10.02s | 7.25s | **−27.6%** |
| client TTFT avg | 30.75s | 24.33s | **−20.9%** |
| throughput (tokens / 300s) | 8.98M | 9.51M | **+5.9%** |

Null control (low concurrency, load_back≈0) shows identical `prefill_forward` across both arms (5.33s vs 5.31s), confirming the gain is attributable to the gather kernel and not run-to-run noise.

## Scope
- HIP default only (`16 if _is_hip else 2`), mirroring the adjacent `num_warps_per_block`.
- Other gather paths (layer_first load_back, device→host backup) left at the default 2 (not measured here).
- `num_warps_per_block` unchanged (kept single-variable).
