### PR TITLE
fix: tolerate invalid JSON in assistant history tool_call arguments

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -127,7 +127,17 @@ def normalize_assistant_tool_call_arguments(message: Dict[str, Any]) -> None:
         if not isinstance(function, dict):
             continue
         if "arguments" in function and isinstance(function["arguments"], str):
-            function["arguments"] = parse_tool_call_arguments(function["arguments"])
+            try:
+                function["arguments"] = parse_tool_call_arguments(
+                    function["arguments"]
+                )
+            except ValueError:
+                # A prior-turn assistant tool call may carry arguments that are
+                # not valid JSON (e.g. produced by an upstream model or client).
+                # A malformed history turn must not abort current-turn
+                # generation, so keep the raw string and let the chat template
+                # render it as-is.
+                pass
 
 
 def _extract_max_dynamic_patch(request: ChatCompletionRequest):


### PR DESCRIPTION
A prior-turn assistant message may carry tool_call arguments that are not valid JSON (e.g. produced by an upstream model or client). Currently the OpenAI chat entrypoint runs orjson.loads on these history arguments and raises ValueError on failure, which aborts the whole request with HTTP 400 even though the malformed turn is only history.

This makes the chat path stricter than reference providers (e.g. Moonshot's Kimi API), which accept such requests and answer normally based on context.

Scope the tolerance to the history-normalization path only: on parse failure keep the raw string and let the chat template render it as-is. The current-turn validation and the generic parse helper are unchanged. This only affects requests that previously hard-failed (400), so it is a pure robustness improvement with no regression for currently-succeeding traffic.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #28005502215](https://github.com/inkcherry/sglang/actions/runs/28005502215)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #28005502054](https://github.com/inkcherry/sglang/actions/runs/28005502054)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->